### PR TITLE
openDialog -> openPanel

### DIFF
--- a/lib/open-dialog.js
+++ b/lib/open-dialog.js
@@ -11,7 +11,7 @@ module.exports = function openDialog(document, options, callback) {
     options = {}
   }
 
-  var dialog = NSOpenPanel.openDialog()
+  var dialog = NSOpenPanel.openPanel()
 
   if (options.title) {
     dialog.title = options.title


### PR DESCRIPTION
I got the following error when using `dialog.showOpenDialog`:

```
TypeError: NSOpenPanel.openDialog is not a function. (In 'NSOpenPanel.openDialog()', 'NSOpenPanel.openDialog' is undefined)
line: 34465
sourceURL: /Users/timon/Projects/personal/sketch-palette-generator/sketch-palette-generator.sketchplugin/Contents/Sketch/index.js
column: 38
```

This is because `openDialog` uses `NSOpenPanel.openDialog`, but it should be `NSOpenPanel.openPanel`.