### PR TITLE
:bug: fix openDialog return value

### DIFF
--- a/lib/open-dialog.js
+++ b/lib/open-dialog.js
@@ -56,8 +56,7 @@ module.exports = function openDialog(document, options, callback) {
       dialog.resolvesAliases = !options.properties.noResolveAliases
     }
     if (typeof options.properties.treatPackageAsDirectory !== 'undefined') {
-      dialog.treatsFilePackagesAsDirectories =
-        options.properties.treatPackageAsDirectory
+      dialog.treatsFilePackagesAsDirectories = options.properties.treatPackageAsDirectory
     }
   }
 
@@ -76,10 +75,10 @@ module.exports = function openDialog(document, options, callback) {
     }
 
     if (callback) {
-      callback(urls)
+      callback(result)
       return undefined
     }
-    return urls
+    return result
   }
   return []
 }


### PR DESCRIPTION
`result` is the value which should be returned, isn't it?