### PR TITLE
Big Sur save dialog file extension support.

### DIFF
--- a/lib/save-dialog.js
+++ b/lib/save-dialog.js
@@ -49,7 +49,13 @@ function setupOptions(document, options) {
       })
     })
 
+    if (dialog.allowedContentTypes) {
+      // Big Sur and newer.
+      dialog.allowedContentTypes = exts.map((ext) => UTType.typeWithFilenameExtension(ext))
+    } else {
+      // Catalina and older.
     dialog.allowedFileTypes = exts
+  }
   }
 
   if (options.message) {

--- a/lib/save-dialog.js
+++ b/lib/save-dialog.js
@@ -54,8 +54,6 @@ function setupOptions(document, options) {
       dialog.allowedContentTypes = exts.map((ext) => UTType.typeWithFilenameExtension(ext))
     } else {
       // Catalina and older.
-    dialog.allowedFileTypes = exts
-  }
       dialog.allowedFileTypes = exts
     }
   }

--- a/lib/save-dialog.js
+++ b/lib/save-dialog.js
@@ -56,6 +56,8 @@ function setupOptions(document, options) {
       // Catalina and older.
     dialog.allowedFileTypes = exts
   }
+      dialog.allowedFileTypes = exts
+    }
   }
 
   if (options.message) {


### PR DESCRIPTION
`allowedFileTypes` is deprecated and while you can still call it, it does not appear to work.